### PR TITLE
Test included inside mod tests block

### DIFF
--- a/crates/chainio/clients/fireblocks/src/client.rs
+++ b/crates/chainio/clients/fireblocks/src/client.rs
@@ -40,8 +40,13 @@ pub struct ErrorResponse {
     pub code: i32,
 }
 
-#[test]
-fn test_asset_id_by_chain() {
-    let asset_id_by_chain = asset_id_by_chain();
-    assert_eq!(AssetID::ETH, *asset_id_by_chain.get(&1).unwrap());
+#[cfg(test)]
+mod tests {
+    use super::{asset_id_by_chain, AssetID};
+
+    #[test]
+    fn test_asset_id_by_chain() {
+        let asset_id_by_chain = asset_id_by_chain();
+        assert_eq!(AssetID::ETH, *asset_id_by_chain.get(&1).unwrap());
+    }
 }

--- a/crates/contracts/bindings/src/generate_bindings.rs
+++ b/crates/contracts/bindings/src/generate_bindings.rs
@@ -1,5 +1,4 @@
-
-
+#[cfg(test)]
 mod tests {
 
     use ethers::prelude::Abigen;

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -159,20 +159,26 @@ impl EthConvert {
     }
 }
 
-#[test]
-fn test_map_parity() {
-    use std::str::FromStr;
-    // taken from golang impl
-    let x = Fq::from_str(
-        "21808877952123445795107598745041753552237365029343566086488416315631580963384",
-    )
-    .unwrap();
-    let y = Fq::from_str(
-        "11638128931416599220980524115187668264422283409187640152391635080130668110949",
-    )
-    .unwrap();
-    let expected = PublicKey::new(x, y);
-    let msg = b"07c2ee97b7ae54ffe597b9db97ede3b7";
-    let r = BlsKeypair::map_to_curve(msg).unwrap();
-    assert_eq!(r, expected);
+#[cfg(test)]
+mod tests {
+    use super::{BlsKeypair, PublicKey};
+    use ark_bn254::Fq;
+
+    #[test]
+    fn test_map_parity() {
+        use std::str::FromStr;
+        // taken from golang impl
+        let x = Fq::from_str(
+            "21808877952123445795107598745041753552237365029343566086488416315631580963384",
+        )
+        .unwrap();
+        let y = Fq::from_str(
+            "11638128931416599220980524115187668264422283409187640152391635080130668110949",
+        )
+        .unwrap();
+        let expected = PublicKey::new(x, y);
+        let msg = b"07c2ee97b7ae54ffe597b9db97ede3b7";
+        let r = BlsKeypair::map_to_curve(msg).unwrap();
+        assert_eq!(r, expected);
+    }
 }


### PR DESCRIPTION
Since tests should be compiled only when running `cargo test`, this PR put the tests inside a `mod tests` module.